### PR TITLE
CI and upload current book to gh-pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI/CD
+
+on:
+  push:
+    branches:
+      - '*'       # matches every branch
+      - '*/*'     # matches every branch containing a single '/'
+      - '!master' # excludes master
+  pull_request:
+  # Run daily at 0:01 UTC
+  schedule:
+  - cron:  '1 0 * * *'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.7' ]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Compile book
+      uses: docker://xucheng/texlive-full:latest
+      with:
+        entrypoint: /bin/sh
+        args: |
+          -c "\
+          apk --no-cache add make && \
+          make all"
+    - name: List directory contents
+      run: ls -lhtra

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Deploy build
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.7' ]
+
+    steps:
+    - name: Checkout book
+      uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Compile book
+      uses: docker://xucheng/texlive-full:latest
+      with:
+        entrypoint: /bin/sh
+        args: |
+          -c "\
+          apk --no-cache add make && \
+          make all"
+    - name: List directory contents
+      run: ls -lhtra
+    - name: Setup build for deployment
+      run: |
+        mkdir -p docs/_build
+        cp main.pdf docs/_build/main.pdf
+    - name: Deploy build to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/_build
+        force_orphan: true
+        user_name: 'github-actions[bot]'
+        user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # pp4fpgas
 Parallel Programming for FPGAs
 
+[![GitHub Actions Status: CI](https://github.com/jmduarte/pp4fpgas/workflows/Deploy%20build/badge.svg)](https://github.com/jmduarte/pp4fpgas/actions?query=workflow%3A"Deploy+build"+branch%3Amaster)
+[![GitHub view](https://img.shields.io/badge/GitHub-render-green.svg)](https://github.com/jmduarte/pp4fpgas/blob/gh-pages/main.pdf)
+[![download](https://img.shields.io/badge/Download-build-blue.svg)](https://github.com/jmduarte/pp4fpgas/raw/gh-pages/main.pdf)
+
 Ryan Kastner, Janarbek Matai, and Stephen Neuendorffer
 
 An open-source high-level synthesis book

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # pp4fpgas
 Parallel Programming for FPGAs
 
-[![GitHub Actions Status: CI](https://github.com/jmduarte/pp4fpgas/workflows/Deploy%20build/badge.svg)](https://github.com/jmduarte/pp4fpgas/actions?query=workflow%3A"Deploy+build"+branch%3Amaster)
-[![GitHub view](https://img.shields.io/badge/GitHub-render-green.svg)](https://github.com/jmduarte/pp4fpgas/blob/gh-pages/main.pdf)
-[![download](https://img.shields.io/badge/Download-build-blue.svg)](https://github.com/jmduarte/pp4fpgas/raw/gh-pages/main.pdf)
+[![GitHub Actions Status: CI](https://github.com/KastnerRG/pp4fpgas/workflows/Deploy%20build/badge.svg)](https://github.com/KastnerRG/pp4fpgas/actions?query=workflow%3A"Deploy+build"+branch%3Amaster)
+[![GitHub view](https://img.shields.io/badge/GitHub-render-green.svg)](https://github.com/KastnerRG/pp4fpgas/blob/gh-pages/main.pdf)
+[![download](https://img.shields.io/badge/Download-build-blue.svg)](https://github.com/KastnerRG/pp4fpgas/raw/gh-pages/main.pdf)
 
 Ryan Kastner, Janarbek Matai, and Stephen Neuendorffer
 


### PR DESCRIPTION
This PR sets up a CI workflow through GitHub actions to compile the book and also publish it in a `gh-pages` branch.

You can see what it looks like on my fork: https://github.com/jmduarte/pp4fpgas/